### PR TITLE
Convert Player code comments to doc comments

### DIFF
--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -8,38 +8,38 @@ using UnityEngine.SceneManagement;
     /// </summary>
     public class Player : MovingObject
     {
-	/// <summary>Delay time in seconds to restart level.</summary>
+	    /// <summary>Delay duration in seconds to restart level.</summary>
         public float restartLevelDelay = 1f;
-	/// <summary>Number of points to add to player food resource when picking up a food object.</summary>
+	    /// <summary>Number of points to add to player food resource when picking up a food object.</summary>
         public int pointsPerFood = 10;
-	/// <summary>Number of points to add to player food resource when picking up a soda object.</summary>
+	    /// <summary>Number of points to add to player food resource when picking up a soda object.</summary>
         public int pointsPerSoda = 20;
-	/// <summary>How much damage the Player inflicts to the Wall object when it attacks.</summary>
+	    /// <summary>How much damage the Player inflicts to the Wall object when it attacks.</summary>
         public int wallDamage = 1;
         /// <summary>Stores a reference to the Player's animator component.</summary>
         private Animator animator;
-	/// <summary>Stores the Player's current food points during the level.</summary>
+	    /// <summary>Stores the Player's current food points during the level.</summary>
         private int food;
         
-	/// <summary>
-	///   Configures the Player state on entry to the scene.
-	/// </summary>
+        /// <summary>
+        ///   Configures the Player state on entry to the scene.
+        /// </summary>
         protected override void Start ()
         {
-            //Get a component reference to the Player's animator component
+            // Get a component reference to the Player's animator component
             animator = GetComponent<Animator>();
             
-            //Get the current food point total stored in GameManager.instance between levels.
+            // Get the current food point total stored in GameManager.instance between levels.
             food = GameManager.instance.playerHealth;
             
-            //Call the Start function of the MovingObject base class.
+            // Call the Start function of the MovingObject base class.
             base.Start ();
         }
         
-	/// <summary>
-	///   Stores the Player state in the GameManager when the Player GameObject is disabled.
-	///   This is done to carry over the Player state from the current level to the next level.
-	/// </summary>
+        /// <summary>
+        ///   Stores the Player state in the GameManager when the Player GameObject is disabled.
+        ///   This is done to carry over the Player state from the current level to the next level.
+        /// </summary>
         private void OnDisable ()
         {
 	    // Currently only storing the Player's food
@@ -47,31 +47,31 @@ using UnityEngine.SceneManagement;
         }
         
         /// <summary>
-	///   If it's the Player's turn, this method handles updating the Player game logic
-	///   (such as translating player input into movement) on each engine tick. 
-	/// </summary>
+        ///   If it's the Player's turn, this method handles updating the Player game logic
+        ///   (such as translating player input into movement) on each engine tick. 
+        /// </summary>
         private void Update ()
         {
             // If it's not the player's turn, there's no need to process any updates from
-	    // the player.
+	        // the player.
             if(!GameManager.instance.playersTurn || isMoving) return;
 
-	    // Direction to move along the horizontal axis.
+	        // Direction to move along the horizontal axis.
             int horizontal = 0;
-	    // Direction to move along the vertical axis.
+	        // Direction to move along the vertical axis.
             int vertical = 0;
             
-	    // Receive horizontal (arrow key left/right) input from the Input manager.
+	        // Receive horizontal (arrow key left/right) input from the Input manager.
             horizontal = (int) (Input.GetAxisRaw ("Horizontal"));
             
-	    // Receive vertical (arrow key up/down) input from the Input manager.
+	        // Receive vertical (arrow key up/down) input from the Input manager.
             vertical = (int) (Input.GetAxisRaw ("Vertical"));
-	    // NOTE: horizontal and vertical are cast to ints to round to a whole number.
+	        // NOTE: horizontal and vertical are cast to ints to round to a whole number.
 
-	    // NOTE: Player movement is limited to exclusively up, down, left, right.
-	    //       Diagonal/omnidirectional movement is restricted.
-	    // If horizontal movement detected, vertical is set to 0 to avoid movement
-	    // along vertical axis.
+            // NOTE: Player movement is limited to exclusively up, down, left, right.
+            //       Diagonal/omnidirectional movement is restricted.
+            // If horizontal movement detected, vertical is set to 0 to avoid movement
+            // along vertical axis.
             if(horizontal != 0)
             {
                 vertical = 0;
@@ -82,113 +82,127 @@ using UnityEngine.SceneManagement;
                 AttemptMove<Enemy>(horizontal, vertical);
             }
         }
-        
-        //AttemptMove overrides the AttemptMove function in the base class MovingObject
-        //AttemptMove takes a generic parameter T which for Player will be of the type Wall, it also takes integers for x and y direction to move in.
 
-	/// <summary>
-	///   Attempts to move the Player in the direction specified by xDir and yDir. This method will 
-	/// </summary>
+        /// <summary>
+        ///   Attempts to move the Player in the direction specified by xDir and yDir. This method will 
+        /// </summary>
+        /// <param name="xDir">The horizontal direction (left or right).</param>
+        /// <param name="yDir">The vertical direction (up or down).</param>
+        /// <param name="T">
+        ///   An obstruction, such as an enemy or a wall, that could possibly
+        ///   prohibit movement.
+        /// </param>
         protected override void AttemptMove <T> (int xDir, int yDir)
         {
-            //Every time player moves, subtract from food points total.
+            // Every time player moves, subtract from food points total.
             food--;
             
-            //Call the AttemptMove method of the base class, passing in the component T (in this case Wall) and x and y direction to move.
+            // Call the AttemptMove method of the base class, passing in the component T (in this case Wall) and x and y direction to move.
             base.AttemptMove <T> (xDir, yDir);
             
-            //Hit allows us to reference the result of the Linecast done in Move.
+            // Hit allows us to reference the result of the Linecast done in Move.
             RaycastHit2D hit;
             
-            //If Move returns true, meaning Player was able to move into an empty space.
+            // If Move returns true, meaning Player was able to move into an empty space.
             if (Move (xDir, yDir, out hit)) 
             {
-                //Call RandomizeSfx of SoundManager to play the move sound, passing in two audio clips to choose from.
+                // Call RandomizeSfx of SoundManager to play the move sound, passing in two audio clips to choose from.
             }
             
-            //Since the player has moved and lost food points, check if the game has ended.
+            // Since the player has moved and lost food points, check if the game has ended.
             CheckIfGameOver ();
             
-            //Set the playersTurn boolean of GameManager to false now that players turn is over.
+            // Set the playersTurn boolean of GameManager to false now that players turn is over.
             GameManager.instance.playersTurn = false;
         }
         
-        
-        //OnCantMove overrides the abstract function OnCantMove in MovingObject.
-        //It takes a generic parameter T which in the case of Player is a Wall which the player can attack and destroy.
+        /// <summary>
+        ///   This method is called when the Player failed to move in the specified direction.
+        ///   In the event of a destructible wall or enemy, the player can attack to try to
+        ///   remove the obstruction.
+        /// </summary>
+        /// <param name="component">An interactable entity, such as a wall or an enemy.</param>
         protected override void OnCantMove <T> (T component)
         {
 
         }
-        
-        
-        //OnTriggerEnter2D is sent when another object enters a trigger collider attached to this object (2D physics only).
+    
+        /// <summary>
+        ///   Handles collision logic and determines how the Player interaction with
+        /// other with other GameObjects on collision are invoked.
+        /// </summary>
+        /// <param name="other">
+        ///   A reference to the GameObject's collider that the 
+        ///   Player collided into.
+        /// </param>
         private void OnTriggerEnter2D (Collider2D other)
         {
-            //Check if the tag of the trigger collided with is Exit.
+            // Check if the tag of the trigger collided with is Exit.
             if(other.tag == "Exit")
             {
-                //Invoke the Restart function to start the next level with a delay of restartLevelDelay (default 1 second).
+                // Invoke the Restart function to start the next level with a delay of 
+                // restartLevelDelay (default 1 second).
                 Invoke ("Restart", restartLevelDelay);
                 
-                //Disable the player object since level is over.
+                // Disable the player object since level is over.
                 enabled = false;
             }
             
-            //Check if the tag of the trigger collided with is Food.
+            // Check if the tag of the trigger collided with is Food.
             else if(other.tag == "Food")
             {
-                //Add pointsPerFood to the players current food total.
+                // Add pointsPerFood to the players current food total.
                 food += pointsPerFood;
                 
-                //Disable the food object the player collided with.
+                // Disable the food object the player collided with.
                 other.gameObject.SetActive (false);
             }
             
-            //Check if the tag of the trigger collided with is Soda.
+            // Check if the tag of the trigger collided with is Soda.
             else if(other.tag == "Soda")
             {
-                //Add pointsPerSoda to players food points total
+                // Add pointsPerSoda to players food points total
                 food += pointsPerSoda;
                 
                 
-                //Disable the soda object the player collided with.
+                // Disable the soda object the player collided with.
                 other.gameObject.SetActive (false);
             }
         }
         
-        
-        //Restart reloads the scene when called.
+        /// <summary>
+        ///   Reloads the scene.
+        /// </summary>
         private void Restart ()
         {
-            //Load the last scene loaded, in this case Main, the only scene in the game.
+            // Load the last scene loaded, in this case Main, the only scene in the game.
             SceneManager.LoadScene (0);
         }
         
-        
-        //LoseFood is called when an enemy attacks the player.
-        //It takes a parameter loss which specifies how many points to lose.
+        /// <summary>
+        ///   Reduces the Player's food resource.
+        /// </summary>
+        /// <param name="loss">The amount of food to deduct from Player's food count.</param>
         public void LoseFood (int loss)
         {
-            //Set the trigger for the player animator to transition to the playerHit animation.
+            // Set the trigger for the player animator to transition to the playerHit animation.
             animator.SetTrigger ("playerHit");
             
-            //Subtract lost food points from the players total.
+            // Subtract lost food points from the players total.
             food -= loss;
             
-            //Check to see if game has ended.
+            // Check to see if game has ended.
             CheckIfGameOver ();
         }
         
-        
-        //CheckIfGameOver checks if the player is out of food points and if so, ends the game.
+        /// <summary>
+        ///   If a defeat condition has been reached (such as running out of food), end the game.
+        ///</summary>
         private void CheckIfGameOver ()
         {
-            //Check if food point total is less than or equal to zero.
+            // Check if food point total is less than or equal to zero.
             if (food <= 0) 
             {
-                
-                //Call the GameOver function of GameManager.
                 GameManager.instance.GameOver ();
             }
         }

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -1,18 +1,25 @@
 ﻿using UnityEngine;
 using System.Collections;
-using UnityEngine.SceneManagement;      //Allows us to use SceneManager
+using UnityEngine.SceneManagement;
 
-    //Player inherits from MovingObject, our base class for objects that can move, Enemy also inherits from this.
+    /// <summary>
+    ///   This class contains logic for processing player input and interacting with other relevant
+    ///   GameObjects in the generated scene.
+    /// </summary>
     public class Player : MovingObject
     {
-        public float restartLevelDelay = 1f;        //Delay time in seconds to restart level.
-        public int pointsPerFood = 10;              //Number of points to add to player food points when picking up a food object.
-        public int pointsPerSoda = 20;              //Number of points to add to player food points when picking up a soda object.
-        public int wallDamage = 1;                  //How much damage a player does to a wall when chopping it.
-        
-        
-        private Animator animator;                  //Used to store a reference to the Player's animator component.
-        private int food;                           //Used to store player food points total during level.
+	/// <summary>Delay time in seconds to restart level.</summary>
+        public float restartLevelDelay = 1f;
+	/// <summary>Number of points to add to player food resource when picking up a food object.</summary>
+        public int pointsPerFood = 10;
+	/// <summary>Number of points to add to player food resource when picking up a soda object.</summary>
+        public int pointsPerSoda = 20;
+	/// <summary>How much damage the Player inflicts to the Wall object when it attacks.</summary>
+        public int wallDamage = 1;
+        /// <summary>Stores a reference to the Player's animator component.</summary>
+        private Animator animator;
+	/// <summary>Stores the Player's current food points during the level.</summary>
+        private int food;
         
         //Start overrides the Start function of MovingObject
         protected override void Start ()

--- a/Assets/Scripts/Player.cs
+++ b/Assets/Scripts/Player.cs
@@ -21,7 +21,9 @@ using UnityEngine.SceneManagement;
 	/// <summary>Stores the Player's current food points during the level.</summary>
         private int food;
         
-        //Start overrides the Start function of MovingObject
+	/// <summary>
+	///   Configures the Player state on entry to the scene.
+	/// </summary>
         protected override void Start ()
         {
             //Get a component reference to the Player's animator component
@@ -34,37 +36,47 @@ using UnityEngine.SceneManagement;
             base.Start ();
         }
         
-        
-        //This function is called when the behaviour becomes disabled or inactive.
+	/// <summary>
+	///   Stores the Player state in the GameManager when the Player GameObject is disabled.
+	///   This is done to carry over the Player state from the current level to the next level.
+	/// </summary>
         private void OnDisable ()
         {
-            //When Player object is disabled, store the current local food total in the GameManager so it can be re-loaded in next level.
+	    // Currently only storing the Player's food
             GameManager.instance.playerHealth = food;
         }
         
-        
+        /// <summary>
+	///   If it's the Player's turn, this method handles updating the Player game logic
+	///   (such as translating player input into movement) on each engine tick. 
+	/// </summary>
         private void Update ()
         {
-            //If it's not the player's turn, exit the function.
+            // If it's not the player's turn, there's no need to process any updates from
+	    // the player.
             if(!GameManager.instance.playersTurn || isMoving) return;
+
+	    // Direction to move along the horizontal axis.
+            int horizontal = 0;
+	    // Direction to move along the vertical axis.
+            int vertical = 0;
             
-            int horizontal = 0;     //Used to store the horizontal move direction.
-            int vertical = 0;       //Used to store the vertical move direction.
-            
-            
-            //Get input from the input manager, round it to an integer and store in horizontal to set x axis move direction
+	    // Receive horizontal (arrow key left/right) input from the Input manager.
             horizontal = (int) (Input.GetAxisRaw ("Horizontal"));
             
-            //Get input from the input manager, round it to an integer and store in vertical to set y axis move direction
+	    // Receive vertical (arrow key up/down) input from the Input manager.
             vertical = (int) (Input.GetAxisRaw ("Vertical"));
-            
-            //Check if moving horizontally, if so set vertical to zero.
+	    // NOTE: horizontal and vertical are cast to ints to round to a whole number.
+
+	    // NOTE: Player movement is limited to exclusively up, down, left, right.
+	    //       Diagonal/omnidirectional movement is restricted.
+	    // If horizontal movement detected, vertical is set to 0 to avoid movement
+	    // along vertical axis.
             if(horizontal != 0)
             {
                 vertical = 0;
             }
             
-            //Check if we have a non-zero value for horizontal or vertical
             if(horizontal != 0 || vertical != 0)
             {
                 AttemptMove<Enemy>(horizontal, vertical);
@@ -73,6 +85,10 @@ using UnityEngine.SceneManagement;
         
         //AttemptMove overrides the AttemptMove function in the base class MovingObject
         //AttemptMove takes a generic parameter T which for Player will be of the type Wall, it also takes integers for x and y direction to move in.
+
+	/// <summary>
+	///   Attempts to move the Player in the direction specified by xDir and yDir. This method will 
+	/// </summary>
         protected override void AttemptMove <T> (int xDir, int yDir)
         {
             //Every time player moves, subtract from food points total.


### PR DESCRIPTION
This PR connects to #38.

#38 should remain open, as this PR does not complete all the work. This PR is mainly to provide a reference for how other comments should be structured in source code. 

We should actively incorporate this into development ASAP so documentation does not lag too far behind development.

Briefly:

- A Doc comment is started with `///`, not just `//` or `/*`.
- **_Every_** **class declaration**, **field**, and **method** should have _at least_ a `<summary>` inside of a Doc comment.
- Methods with parameters should have `<param>` in the Doc comment block following the summary.
- A `<summary></summary>` and `<param></param>` should be placed on one line for **fields** and **parameters** provided it doesn't exceed 120 characters to save space. If it does get pretty long, convert it to a block.