### PR TITLE
Fix collisions: Re-attach BlockingLayer reference to Enemy and Player prefabs

### DIFF
--- a/Assets/Prefabs/Enemy.prefab
+++ b/Assets/Prefabs/Enemy.prefab
@@ -117,10 +117,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 452c0a0fe6aea13459d8410e0b88e229, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  moveTime: 0.1
-  blockingLayer:
+  BlockingLayer:
     serializedVersion: 2
     m_Bits: 512
+  MoveTime: 0.1
   speed: 1
   min_range: 0
   max_range: 1

--- a/Assets/Prefabs/PlayerSeal.prefab
+++ b/Assets/Prefabs/PlayerSeal.prefab
@@ -117,14 +117,14 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cf7fa84b1cbb7ab459b05ce1a72ef24c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  moveTime: 0.1
-  blockingLayer:
+  BlockingLayer:
     serializedVersion: 2
     m_Bits: 512
-  restartLevelDelay: 1
-  pointsPerFood: 10
-  pointsPerSoda: 20
-  wallDamage: 1
+  MoveTime: 0.1
+  PointsPerFood: 10
+  PointsPerSoda: 20
+  RestartLevelDelay: 1
+  WallDamage: 1
 --- !u!212 &212665703806811212
 SpriteRenderer:
   m_ObjectHideFlags: 1


### PR DESCRIPTION
Fixes the dropped references from the great reconditioning of #38.

Note to selves: Unity editor will drop attached references to prefab properties when renamed apparently.