### PR TITLE
Fix "Vector2 compare is always true"

### DIFF
--- a/Assets/Scripts/AI/SearchAStar.cs
+++ b/Assets/Scripts/AI/SearchAStar.cs
@@ -70,7 +70,7 @@ public class SearchAStar {
                 endLoc = new Vector2(con.Destination.x, con.Destination.y);
                 endCost = current.CostSoFar + con.Cost;
 
-                if (_debugMode && con.From != null) {
+                if (_debugMode && con.From != Vector2.zero) {
                     UnityEngine.Debug.DrawLine(con.From, con.Destination, Color.blue,2,false);
                 }
 


### PR DESCRIPTION
Closes #83.

Unity's Vector2 is a struct which is a _value_ type which cannot be `null`. Closest to a null condition would be `Vector2.zero`