### PR TITLE
Fix over-generation of health & mana

### DIFF
--- a/Assets/Scripts/Combat/CombatData.cs
+++ b/Assets/Scripts/Combat/CombatData.cs
@@ -116,13 +116,13 @@ namespace Combat {
         ///     The health of this object
         /// </summary>
         [Range(0, 200)] public int HealthPoints;
-        private int _maxHealthPoints;
+        public int MaxHealthPoints { get; set; }
 
         /// <summary>
         ///     ManaPoints from combat
         /// </summary>
         [Range(0, 200)] public int ManaPoints;
-        private int _maxManaPoints;
+        public int MaxManaPoints { get; set; }
         /// <summary>
         ///     The sealie (melee) attack info
         /// </summary>
@@ -162,8 +162,8 @@ namespace Combat {
         }
 
         void Awake() {
-            _maxHealthPoints = HealthPoints;
-            _maxManaPoints = ManaPoints;
+            MaxHealthPoints = HealthPoints;
+            MaxManaPoints = ManaPoints;
         }
 
         public TemporaryCombatData ToTemporaryCombatData() {
@@ -176,9 +176,9 @@ namespace Combat {
         /// <param name="amount">
         /// The amount of hit points the player regenerates.
         /// </param>
-        public void Heal(ushort amount) {
-            if (HealthPoints + amount >= _maxHealthPoints) {
-                HealthPoints = _maxHealthPoints;
+        public void Heal(int amount) {
+            if (HealthPoints + amount >= MaxHealthPoints) {
+                HealthPoints = MaxHealthPoints;
             } else {
                 HealthPoints += amount;
             }
@@ -190,9 +190,9 @@ namespace Combat {
         /// <param name="amount">
         /// The amount of mana points the player regenerates.
         /// </param>
-        public void RechargeMana(ushort amount) {
-            if (ManaPoints + amount >= _maxManaPoints) {
-                ManaPoints = _maxManaPoints;
+        public void RechargeMana(int amount) {
+            if (ManaPoints + amount >= MaxManaPoints) {
+                ManaPoints = MaxManaPoints;
             } else {
                 ManaPoints += amount;
             }

--- a/Assets/Scripts/Combat/CombatData.cs
+++ b/Assets/Scripts/Combat/CombatData.cs
@@ -116,12 +116,14 @@ namespace Combat {
         ///     The health of this object
         /// </summary>
         [Range(0, 200)] public int HealthPoints;
+        /// <summary>The maximum amount of health points possible.</summary>
         public int MaxHealthPoints { get; set; }
 
         /// <summary>
         ///     ManaPoints from combat
         /// </summary>
         [Range(0, 200)] public int ManaPoints;
+        /// <summary>The maximum amount of mana points possible.</summary>
         public int MaxManaPoints { get; set; }
         /// <summary>
         ///     The sealie (melee) attack info

--- a/Assets/Scripts/Combat/CombatData.cs
+++ b/Assets/Scripts/Combat/CombatData.cs
@@ -116,12 +116,13 @@ namespace Combat {
         ///     The health of this object
         /// </summary>
         [Range(0, 200)] public int HealthPoints;
+        private int _maxHealthPoints;
 
         /// <summary>
         ///     ManaPoints from combat
         /// </summary>
         [Range(0, 200)] public int ManaPoints;
-
+        private int _maxManaPoints;
         /// <summary>
         ///     The sealie (melee) attack info
         /// </summary>
@@ -160,8 +161,41 @@ namespace Combat {
             get { return _defenseEffects; }
         }
 
+        void Awake() {
+            _maxHealthPoints = HealthPoints;
+            _maxManaPoints = ManaPoints;
+        }
+
         public TemporaryCombatData ToTemporaryCombatData() {
             return new TemporaryCombatData(this);
+        }
+
+        /// <summary>
+        /// Heals the player, discarding any over heal.
+        /// </summary>
+        /// <param name="amount">
+        /// The amount of hit points the player regenerates.
+        /// </param>
+        public void Heal(ushort amount) {
+            if (HealthPoints + amount >= _maxHealthPoints) {
+                HealthPoints = _maxHealthPoints;
+            } else {
+                HealthPoints += amount;
+            }
+        }
+
+        /// <summary>
+        /// Recharges the player's mana, discarding any over generation.
+        /// </summary>
+        /// <param name="amount">
+        /// The amount of mana points the player regenerates.
+        /// </param>
+        public void RechargeMana(ushort amount) {
+            if (ManaPoints + amount >= _maxManaPoints) {
+                ManaPoints = _maxManaPoints;
+            } else {
+                ManaPoints += amount;
+            }
         }
 
         /// <summary>

--- a/Assets/Scripts/Item/Consumables/Food.cs
+++ b/Assets/Scripts/Item/Consumables/Food.cs
@@ -32,15 +32,7 @@ public class Food : Consumable {
         var player = FindObjectOfType<Player>();
         var combatData = player.GetComponent<CombatData>();
 
-        combatData.HealthPoints += (HealthMod * Multiplier);
-
-        //var newHealth = GameManager.Instance.PlayerHealth + HealthMod * Multiplier;
-
-        //if (newHealth > ushort.MaxValue) {
-        //    newHealth = ushort.MaxValue;
-        //}
-
-        //GameManager.Instance.PlayerHealth = (short)newHealth;
+        combatData.Heal((ushort)(HealthMod * Multiplier));
 
         base.Consume();
     }

--- a/Assets/Scripts/Item/Consumables/Food.cs
+++ b/Assets/Scripts/Item/Consumables/Food.cs
@@ -32,7 +32,7 @@ public class Food : Consumable {
         var player = FindObjectOfType<Player>();
         var combatData = player.GetComponent<CombatData>();
 
-        combatData.Heal((ushort)(HealthMod * Multiplier));
+        combatData.Heal(HealthMod * Multiplier);
 
         base.Consume();
     }


### PR DESCRIPTION
My attempt at #117.

Adds methods to `CombatData` to interface with health and mana regeneration. These methods are _constrained_ and will not over-heal/over-generate.

I'm assuming `Food` items won't be poisonous initially, so I've had the `Food` class invoke `Heal()` on the combat data object. If they were poisonous, perhaps there could be a bool we could use and then it can call the appropriate damaging methods on the combat data.

However, I'd like a couple set of eyes on this PR because this is my concern:

The private variables I use to track maximum health and mana are set on `Awake()`. I don't know how this transfers over from scene to scene. 

Result: Player cannot overheal by binging on all of the delicious fishies.